### PR TITLE
Fix examples links on Firefox

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -66,6 +66,7 @@ header a:hover {color: #AEC126; border-bottom: 1px solid #AEC126;}
 #imgWrapper a {border: none; padding: 0px;}
 
 .exampleItem {display: inline-block; position: relative; margin: 0px 18px 34px 0px;  }
+.exampleItem a {display: block; }
 .exampleItem cite {float: left; position: absolute;  }
 
 /* MODULES */


### PR DESCRIPTION
The example links looked funky on Firefox (v 24.0). This fixes it.

![capture decran 2013-11-03 a 21 12 25](https://f.cloud.github.com/assets/1272948/1461713/9b9f1098-44c5-11e3-93fd-05dca8dac098.png)
