### PR TITLE
fix embedded requirebin npm search + issue #10

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
           <a href="https://twitter.com/voxeljs" class="twitter-follow-button" data-show-count="false" data-dnt="true" target="_blank">Follow @voxeljs</a>
         </li>
         <li>
-          #voxel.js on freenode
+          <a href="http://webchat.freenode.net/?randomnick=1&channels=voxel.js" target="_blank">#voxel.js on freenode</a>
         </li>
       </ul>
 
@@ -171,7 +171,7 @@
     <h3><a name="addons" class="anchor" href="#addons"><span class="mini-icon mini-icon-link"></span></a>Add-ons</h3>
       <div class="addons">
         <p>There are around 200 addons for voxel.js published on <a href="https://www.npmjs.org/search?q=voxel">NPM</a>, here are live search results for all the modules on NPM with word 'voxel' in the title/description:</p>
-        <iframe width="800" height="315" src="http://requirebin.com/embed?gist=11123800" frameborder="0" allowfullscreen></iframe>
+        <iframe width="800" height="315" src="http://requirebin.com/embed?gist=42912696f0f6f7355464" frameborder="0" allowfullscreen></iframe>
       </div>
       
   </article>


### PR DESCRIPTION
This PR corrects an issue with the embedded requirebin that queries npm for the packages with "voxel" in the title/description. I [forked the gist](http://requirebin.com/?gist=42912696f0f6f7355464) and pulled in the updated version in index.html. I wasn't entirely sure if I could just update the existing gist, but please let me know if you'd like me to do this a different way.

I also threw in a freenode webchat link for #10. I understand we could use a link to a native client instead, but I figured this was a good alternative to not having a link at all.

Let me know what you think!
